### PR TITLE
Update `kotlin-components` submodule

### DIFF
--- a/library/kmp-tor-binary-extract/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/binary/extract/ExtractorUnitTest.kt
+++ b/library/kmp-tor-binary-extract/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/binary/extract/ExtractorUnitTest.kt
@@ -15,17 +15,16 @@
  **/
 package io.matthewnelson.kmp.tor.binary.extract
 
-import io.matthewnelson.component.encoding.base16.encodeBase16
-import io.matthewnelson.kmp.tor.binary.extract.internal.FILE_NAME_SHA256_SUFFIX
+import io.matthewnelson.encoding.builders.Base16
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import java.io.File
 import java.security.MessageDigest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 actual class ExtractorUnitTest: BaseExtractorJvmJsUnitTest() {
+
+    companion object {
+        private val base16 = Base16 { encodeToLowercase = true }
+    }
 
     override val extractor: Extractor = Extractor()
     override val fsSeparator: Char = File.separatorChar
@@ -41,7 +40,7 @@ actual class ExtractorUnitTest: BaseExtractorJvmJsUnitTest() {
         val digest = MessageDigest.getInstance("SHA-256")
         digest.reset()
         digest.update(bytes, 0, bytes.size)
-        return digest.digest().encodeBase16().lowercase()
+        return digest.digest().encodeToString(base16)
     }
 
     override fun deleteTestDir() {


### PR DESCRIPTION
Closes #53 

 - Updates the git submodule to latest commit
 - Updates `encoding` deprecations to new API