### PR TITLE
Use reflection to find `Loader` class to load resources from

### DIFF
--- a/library/kmp-tor-binary-extract/api/jvm/kmp-tor-binary-extract.api
+++ b/library/kmp-tor-binary-extract/api/jvm/kmp-tor-binary-extract.api
@@ -13,7 +13,9 @@ public final class io/matthewnelson/kmp/tor/binary/extract/Extractor {
 public final class io/matthewnelson/kmp/tor/binary/extract/TorBinaryResource : io/matthewnelson/kmp/tor/binary/extract/TorResource$Binaries {
 	public static final field Companion Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource$Companion;
 	public final field arch Ljava/lang/String;
-	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource$OS;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final field loadPath Ljava/lang/String;
+	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource$OS;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun from (Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource$OS;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource;
 	public static final fun from (Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource$OS;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource;
 	public fun getResourceDirPath ()Ljava/lang/String;
 	public fun getResourceManifest ()Ljava/util/List;
@@ -22,6 +24,7 @@ public final class io/matthewnelson/kmp/tor/binary/extract/TorBinaryResource : i
 }
 
 public final class io/matthewnelson/kmp/tor/binary/extract/TorBinaryResource$Companion {
+	public final fun from (Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource$OS;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource;
 	public final fun from (Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource$OS;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/matthewnelson/kmp/tor/binary/extract/TorBinaryResource;
 }
 

--- a/library/kmp-tor-binary-extract/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/-JsPlatform.kt
+++ b/library/kmp-tor-binary-extract/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/-JsPlatform.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
+package io.matthewnelson.kmp.tor.binary.extract
+
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun String?.toLoadPath(os: TorBinaryResource.OS, arch: String): String {
+    if (this == null) {
+        return "kmp-tor-resource-${os.lowercaseName}$arch"
+    }
+
+    return if (endsWith('-')) {
+        "$this${os.lowercaseName}$arch"
+    } else {
+        "$this-${os.lowercaseName}$arch"
+    }
+}

--- a/library/kmp-tor-binary-extract/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/Extractor.kt
+++ b/library/kmp-tor-binary-extract/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/Extractor.kt
@@ -16,7 +16,6 @@
 package io.matthewnelson.kmp.tor.binary.extract
 
 import io.matthewnelson.kmp.tor.binary.extract.internal.ExtractorDelegateJs
-import io.matthewnelson.kmp.tor.binary.extract.internal.jsModuleName
 import io.matthewnelson.kmp.tor.binary.extract.internal.readFileSync
 
 
@@ -77,7 +76,7 @@ public actual class Extractor {
                 is TorResourceMacosX64 -> "kmp-tor-binary-macosx64"
                 is TorResourceMingwX64 -> "kmp-tor-binary-mingwx64"
                 is TorResourceMingwX86 -> "kmp-tor-binary-mingwx86"
-                is TorBinaryResource -> resource.jsModuleName
+                is TorBinaryResource -> resource.loadPath
             } + "/$resourcePath"
 
             val resolvedPath = try {

--- a/library/kmp-tor-binary-extract/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/internal/-TorBinaryResource.kt
+++ b/library/kmp-tor-binary-extract/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/internal/-TorBinaryResource.kt
@@ -1,5 +1,0 @@
-package io.matthewnelson.kmp.tor.binary.extract.internal
-
-import io.matthewnelson.kmp.tor.binary.extract.TorBinaryResource
-
-internal val TorBinaryResource.jsModuleName: String get() = "kmp-tor-resource-${osName}$arch"

--- a/library/kmp-tor-binary-extract/src/jvmJsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/-JvmJsPlatform.kt
+++ b/library/kmp-tor-binary-extract/src/jvmJsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/-JvmJsPlatform.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
+package io.matthewnelson.kmp.tor.binary.extract
+
+@Suppress("NOTHING_TO_INLINE")
+internal expect inline fun String?.toLoadPath(os: TorBinaryResource.OS, arch: String): String

--- a/library/kmp-tor-binary-extract/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/-JvmPlatform.kt
+++ b/library/kmp-tor-binary-extract/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/-JvmPlatform.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
+package io.matthewnelson.kmp.tor.binary.extract
+
+@JvmSynthetic
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun String?.toLoadPath(os: TorBinaryResource.OS, arch: String): String {
+    if (this == null) {
+        return "io.matthewnelson.kmp.tor.resource.${os.lowercaseName}.$arch.Loader"
+    }
+
+    return if (endsWith('.')) {
+        "$this${os.lowercaseName}.$arch.Loader"
+    } else {
+        "$this.${os.lowercaseName}.$arch.Loader"
+    }
+}

--- a/library/kmp-tor-binary-extract/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/Extractor.kt
+++ b/library/kmp-tor-binary-extract/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/Extractor.kt
@@ -81,8 +81,7 @@ public actual class Extractor {
                 is TorResourceMacosX64 -> findLoaderClass("$prefix.macos.x64.Loader")
                 is TorResourceMingwX64 -> findLoaderClass("$prefix.mingw.x64.Loader")
                 is TorResourceMingwX86 -> findLoaderClass("$prefix.mingw.x86.Loader")
-                is TorResourceGeoip -> findLoaderClass("$prefix.geoip.Loader")
-                is TorResourceGeoip6 -> findLoaderClass("$prefix.geoip.Loader")
+                is TorResource.Geoips -> findLoaderClass("$prefix.geoip.Loader")
             }
         } catch (e: ClassNotFoundException) {
             throw delegate.resourceNotFound(resourcePath, e)

--- a/library/kmp-tor-binary-extract/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/Extractor.kt
+++ b/library/kmp-tor-binary-extract/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/Extractor.kt
@@ -71,17 +71,18 @@ public actual class Extractor {
             return this.javaClass.getResourceAsStream("/$resourcePath")!!
         } catch (_: Throwable) {}
 
+        val prefix = "io.matthewnelson.kmp.tor.binary"
         val loader = try {
             when (this) {
-                is TorBinaryResource -> javaClass
-                is TorResourceLinuxX64 -> findLoaderClass("linux.x64")
-                is TorResourceLinuxX86 -> findLoaderClass("linux.x86")
-                is TorResourceMacosArm64 -> findLoaderClass("macos.arm64")
-                is TorResourceMacosX64 -> findLoaderClass("macos.x64")
-                is TorResourceMingwX64 -> findLoaderClass("mingw.x64")
-                is TorResourceMingwX86 -> findLoaderClass("mingw.x86")
-                is TorResourceGeoip -> findLoaderClass("geoip")
-                is TorResourceGeoip6 -> findLoaderClass("geoip")
+                is TorBinaryResource -> findLoaderClass(loadPath)
+                is TorResourceLinuxX64 -> findLoaderClass("$prefix.linux.x64.Loader")
+                is TorResourceLinuxX86 -> findLoaderClass("$prefix.linux.x86.Loader")
+                is TorResourceMacosArm64 -> findLoaderClass("$prefix.macos.arm64.Loader")
+                is TorResourceMacosX64 -> findLoaderClass("$prefix.macos.x64.Loader")
+                is TorResourceMingwX64 -> findLoaderClass("$prefix.mingw.x64.Loader")
+                is TorResourceMingwX86 -> findLoaderClass("$prefix.mingw.x86.Loader")
+                is TorResourceGeoip -> findLoaderClass("$prefix.geoip.Loader")
+                is TorResourceGeoip6 -> findLoaderClass("$prefix.geoip.Loader")
             }
         } catch (e: ClassNotFoundException) {
             throw delegate.resourceNotFound(resourcePath, e)
@@ -95,9 +96,7 @@ public actual class Extractor {
     }
 
     @Throws(ClassNotFoundException::class)
-    private fun findLoaderClass(classpathSuffix: String): Class<*> {
-        val loaderClasspath = "io.matthewnelson.kmp.tor.binary.$classpathSuffix.Loader"
-
+    private fun findLoaderClass(loaderClasspath: String): Class<*> {
         try {
             return Class.forName(loaderClasspath) ?: throw ClassNotFoundException("Failed to find $loaderClasspath")
         } catch (t: Throwable) {

--- a/library/kmp-tor-binary-extract/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/binary/extract/ExtractorUnitTest.kt
+++ b/library/kmp-tor-binary-extract/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/binary/extract/ExtractorUnitTest.kt
@@ -17,6 +17,7 @@ package io.matthewnelson.kmp.tor.binary.extract
 
 import org.junit.Test
 import java.io.File
+import kotlin.test.assertEquals
 
 actual class ExtractorUnitTest: BaseExtractorJvmJsUnitTest() {
 
@@ -40,9 +41,14 @@ actual class ExtractorUnitTest: BaseExtractorJvmJsUnitTest() {
 
     @Test
     fun givenTestResources_whenExtracted_thenIsSuccessful() {
+        val loaderPrefix = "io.matthewnelson"
+        val os = TorBinaryResource.OS.Linux
+        val arch = "test"
+
         val resource = TorBinaryResource.from(
-            os = TorBinaryResource.OS.Linux,
-            arch = "test",
+            os = os,
+            arch = arch,
+            loadPathPrefix = loaderPrefix,
             sha256sum = "a766e07310b1ede3a06ef889cb46023fed5dc8044b326c20adf342242be92ec6",
             resourceManifest = listOf(
                 "subdir/libcrypto.so.1.1.gz",
@@ -54,5 +60,6 @@ actual class ExtractorUnitTest: BaseExtractorJvmJsUnitTest() {
         )
 
         assertBinaryResourceExtractionIsSuccessful(resource)
+        assertEquals("$loaderPrefix.${os.lowercaseName}.$arch.Loader", resource.loadPath)
     }
 }

--- a/library/kmp-tor-binary-extract/src/jvmTest/kotlin/io/matthewnelson/linux/test/Loader.kt
+++ b/library/kmp-tor-binary-extract/src/jvmTest/kotlin/io/matthewnelson/linux/test/Loader.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.linux.test
+
+private class Loader


### PR DESCRIPTION
Closes #72

#75 didn't fix it because, when testing it on https://github.com/05nelsonm/kmp-tor-java/tree/snapshot/loader it was not doing a clean extraction on each start, but utilizing the already extracted files located in my `~/.kmp-tor-java` directory.

This PR's change was published as snapshot `4.7.13-4.1-SNAPSHOT` and run with https://github.com/05nelsonm/kmp-tor-java/tree/version/4.7.13-4.1-SNAPSHOT which uses clean extraction on each start.

Adds optional argument `loadPathPrefix` for `TorBinaryResource` so consumers loading their own custom binaries contained in different modules can express a prefix to their `Loader` class which will be found in order to retrieve resources contained in that module/jar (or the module for Nodejs).

