### PR TITLE
Add script for creating resources from unsigned desktop binaries

### DIFF
--- a/library/binary-build/scripts/build_tor.sh
+++ b/library/binary-build/scripts/build_tor.sh
@@ -18,12 +18,6 @@ set -e
 
 readonly TIME_START=$(date +%s)
 
-# Absolute path to the directory which this script resides in
-readonly DIR=$( cd "$( dirname "$0" )" >/dev/null && pwd )
-readonly DIR_BUILT="$DIR/../built"
-readonly DIR_TOR_BUILD="$DIR/../tor-browser-build"
-readonly DIR_TOR_BUILD_OUT="$DIR_TOR_BUILD/out/tor"
-
 # Commands
 readonly CMD_ALL="all"
 
@@ -40,6 +34,16 @@ readonly CMD_M_AARCH64="macos-aarch64"
 readonly CMD_M_X86_64="macos-x86_64"
 readonly CMD_W_I686="windows-i686"
 readonly CMD_W_X86_64="windows-x86_64"
+
+# Absolute path to the directory which this script resides in
+readonly DIR=$( cd "$( dirname "$0" )" >/dev/null && pwd )
+readonly DIR_BUILT="$DIR/../built"
+readonly DIR_TOR_BUILD="$DIR/../tor-browser-build"
+readonly DIR_TOR_BUILD_OUT="$DIR_TOR_BUILD/out/tor"
+
+# Programs
+readonly GIT=$(which git)
+readonly MAKE=$(which make)
 
 help() {
   echo "
@@ -88,8 +92,20 @@ initialize() {
     exit 1
   fi
 
-  check_git
-  check_make
+  if [ "$GIT" = "" ]; then
+    echo "
+    ERROR: git is required to be installed to run this script
+    "
+    exit 1
+  fi
+
+  if [ "$MAKE" = "" ]; then
+    echo "
+    ERROR: make is required to be installed to run this script
+    "
+    exit 1
+  fi
+
   check_tar
 
   change_dir_or_exit "$DIR"

--- a/library/binary-build/scripts/detached_sig_create.sh
+++ b/library/binary-build/scripts/detached_sig_create.sh
@@ -16,19 +16,19 @@
 export LC_ALL=C
 set -e
 
-# Absolute path to the directory which this script resides in
-readonly DIR=$( cd "$( dirname "$0" )" >/dev/null && pwd )
-readonly DIR_BUILT="$DIR/../built"
-readonly DIR_MACOS="$DIR_BUILT/macos"
-readonly DIR_MINGW="$DIR_BUILT/mingw"
-readonly DIR_PROJECT="$DIR/../../.."
-readonly TOOLING="$DIR_PROJECT/tooling"
-
 # Commands
 readonly CMD_MACOS="macos"
 readonly CMD_MINGW="mingw"
 
+# Absolute path to the directory which this script resides in
+readonly DIR=$( cd "$( dirname "$0" )" >/dev/null && pwd )
+readonly DIR_BUILT="$DIR/../built"
+readonly DIR_MACOS="$DIR_BUILT/$CMD_MACOS"
+readonly DIR_MINGW="$DIR_BUILT/$CMD_MINGW"
+readonly DIR_PROJECT="$DIR/../../.."
+
 # Programs
+readonly TOOLING="$DIR_PROJECT/tooling"
 readonly RCODESIGN=$(which rcodesign)
 readonly OSSLSIGNCODE=$(which osslsigncode)
 
@@ -238,6 +238,7 @@ mingw() {
     change_dir_or_exit "$DIR_PROJECT"
 
     for FILE in $FILES; do
+      # Sign each file
       if ! ${OSSLSIGNCODE} sign -certs "$PATH_CERT" \
            -key "$PATH_KEY" \
            -t "http://timestamp.comodoca.com" \
@@ -246,6 +247,8 @@ mingw() {
         exit 1
       fi
 
+      # Create diffs between unsigned, and signed
+      # binaries (.signature files) to be applied later
       ${TOOLING} diff-cli create --diff-ext-name ".signature" "$DIR_UNSIGNED/$FILE" "$DIR_SIGNED/$FILE" "$DIR_SIGNATURES"
     done
 

--- a/library/binary-build/scripts/detached_sig_create.sh
+++ b/library/binary-build/scripts/detached_sig_create.sh
@@ -162,7 +162,13 @@ macos() {
     # Create diffs between unsigned, and signed
     # binaries (.signature files) to be applied later
     for FILE in $FILES; do
-      ${TOOLING} diff-cli create --diff-ext-name ".signature" "$BUNDLE_UNSIGNED/$FILE" "$BUNDLE_TOR/$FILE" "$DIR_SIGNATURES"
+      if ! ${TOOLING} diff-cli create \
+           --diff-ext-name ".signature" \
+           "$BUNDLE_UNSIGNED/$FILE" \
+           "$BUNDLE_TOR/$FILE" \
+           "$DIR_SIGNATURES"; then
+        exit 1
+      fi
     done
 
     change_dir_or_exit "$DIR_SIGNATURES"
@@ -249,7 +255,13 @@ mingw() {
 
       # Create diffs between unsigned, and signed
       # binaries (.signature files) to be applied later
-      ${TOOLING} diff-cli create --diff-ext-name ".signature" "$DIR_UNSIGNED/$FILE" "$DIR_SIGNED/$FILE" "$DIR_SIGNATURES"
+      if ! ${TOOLING} diff-cli create \
+           --diff-ext-name ".signature" \
+           "$DIR_UNSIGNED/$FILE" \
+           "$DIR_SIGNED/$FILE" \
+           "$DIR_SIGNATURES"; then
+         exit 1
+       fi
     done
 
     change_dir_or_exit "$DIR_SIGNATURES"

--- a/library/binary-build/scripts/resources_create.sh
+++ b/library/binary-build/scripts/resources_create.sh
@@ -137,15 +137,130 @@ geoips() {
   rm -rf "$DIR_BUILT/$CMD_GEOIPS"
 
   echo "
-    Geoip files have been copied to module kmp-tor-binary-geoip
+    Geoip files have been copied to
+    the kmp-tor-binary-geoip module
   "
 }
 
-binaries() {
-  # TODO
+check_architecture() {
+  case $1 in
+    "arm64"|"x64"|"x86")
+      return 0
+      ;;
+  esac
+
   echo "
-  $1
+    ERROR: Unknown architecture [$1]
   "
+  exit 1
+}
+
+binaries() {
+  change_dir_or_exit "$DIR_BUILT/$1"
+
+  for ARCHIVE in "$(pwd)"/*-unsigned.tar.gz; do
+    DIR_WORK=$(echo "$ARCHIVE" | sed "s|-unsigned.tar.gz||g")
+    ARCH=$(echo "$DIR_WORK" | rev | cut -d '/' -f 1 | rev | sed "s|tor-$1-||g")
+
+    check_architecture "$ARCH"
+
+    rm -rf "$DIR_WORK"
+    mkdir -p "$DIR_WORK"
+    ${TAR} -xz -C "$DIR_WORK" -f "$ARCHIVE"
+
+    change_dir_or_exit "$DIR_WORK"
+    # shellcheck disable=SC2035
+    FILES=$(${FIND} * -type f)
+
+    # Apply signatures for macos and windows binaries
+    if [ "$1" = "$CMD_MACOS" ] || [ "$1" = "$CMD_MINGW" ]; then
+      DIR_SIGNATURES="$DIR_WORK-signatures"
+
+      # Extract signatures
+      rm -rf "$DIR_SIGNATURES"
+      mkdir -p "$DIR_SIGNATURES"
+      ${TAR} -xz -C "$DIR_SIGNATURES" -f "$DIR_SIGNATURES.tar.gz"
+
+      change_dir_or_exit "$DIR_PROJECT"
+
+      # Apply signatures to each file
+      for FILE in $FILES; do
+        if ! ${TOOLING} diff-cli apply "$DIR_SIGNATURES/$FILE.signature" "$DIR_WORK/$FILE"; then
+          exit 1
+        fi
+
+        # Fix file permissions
+        chmod 700 "$DIR_WORK/$FILE"
+      done
+
+      # Clean up
+      change_dir_or_exit "$DIR_WORK"
+      rm -rf "$DIR_SIGNATURES"
+      sleep 1
+    fi
+
+    # Build sha256 values + file manifest list
+    FILES_MANIFEST=""
+    FILES_SHA256=""
+    for FILE in $FILES; do
+      H=$(SHA256 "$FILE")
+
+      if [ "$FILES_SHA256" = "" ]; then
+        FILES_MANIFEST="\"$FILE.gz\""
+        FILES_SHA256="$H"
+      else
+        FILES_MANIFEST="$FILES_MANIFEST, \"$FILE.gz\""
+        FILES_SHA256="$FILES_SHA256\n$H"
+      fi
+    done
+
+    # Take the sha256 hash of all the sha256 values combined
+    FILES_SHA256=$(echo "$FILES_SHA256" | ${OPENSSL} dgst -sha256 | rev | cut -d ' ' -f 1 | rev)
+
+    # Gzip directory contents
+    ${GZIP} -rn "$DIR_WORK"
+
+    SOURCE_SET="commonMain"
+
+    # macOS binaries go in jvmMain source set
+    if [ "$1" = "$CMD_MACOS" ]; then
+      SOURCE_SET="jvmMain"
+    fi
+
+    DIR_RESOURCES="$DIR/../../kmp-tor-binary-$1$ARCH/src/$SOURCE_SET/resources/kmptor/$1/$ARCH"
+
+    # Remove all old files and copy over new
+    rm -rf "$DIR_RESOURCES"
+    mkdir -p "$DIR_RESOURCES"
+    cp -ar . "$DIR_RESOURCES"
+
+    # Update TorResource.kt data for jvmJs
+    TOR_RESOURCE_KT_JVMJS="$DIR/../../kmp-tor-binary-extract/src/jvmJsMain/kotlin/io/matthewnelson/kmp/tor/binary/extract/TorResource.kt"
+    # shellcheck disable=SC2060
+    CONST_KT_TAG=$(echo "$1_$ARCH" | tr [a-z] [A-Z])
+
+    # Write sha256 & manifest values for jvmJs TorResource.kt
+    sed -i "s|/\* $CONST_KT_TAG \*/ override val resourceManifest: List<String> get() = .*|/\* $CONST_KT_TAG \*/ override val resourceManifest: List<String> get() = listOf($FILES_MANIFEST)|g" "$TOR_RESOURCE_KT_JVMJS"
+    sed -i "s|/\* $CONST_KT_TAG \*/ override val sha256sum: String get() = .*|/\* $CONST_KT_TAG \*/ override val sha256sum: String get() = \"$FILES_SHA256\"|g" "$TOR_RESOURCE_KT_JVMJS"
+
+    # Linux x64 & Mingw x64 binaries also have values that
+    # need to be updated for native TorResource.kt
+    if [ "$ARCH" = "x64" ]; then
+      if [ "$1" != "$CMD_MACOS" ]; then
+        TOR_RESOURCE_KT_NATIVE="$DIR/../../kmp-tor-binary-extract/src/$1X64Main/kotlin/io/matthewnelson/kmp/tor/binary/extract/TorResource.kt"
+        sed -i "s|/\* $CONST_KT_TAG \*/ override val resourceManifest: List<String> get() = .*|/\* $CONST_KT_TAG \*/ override val resourceManifest: List<String> get() = listOf($FILES_MANIFEST)|g" "$TOR_RESOURCE_KT_NATIVE"
+        sed -i "s|/\* $CONST_KT_TAG \*/ override val sha256sum: String get() = .*|/\* $CONST_KT_TAG \*/ override val sha256sum: String get() = \"$FILES_SHA256\"|g" "$TOR_RESOURCE_KT_NATIVE"
+      fi
+    fi
+
+    change_dir_or_exit "$DIR_BUILT/$1"
+    rm -rf "$DIR_WORK"
+
+    echo "
+    Tor binaries for $1[$ARCH] have been moved to
+    kmp-tor-binary-$1$ARCH module $SOURCE_SET/resources
+    "
+  done
 }
 
 case $1 in

--- a/library/binary-build/scripts/resources_create.sh
+++ b/library/binary-build/scripts/resources_create.sh
@@ -185,12 +185,14 @@ binaries() {
 
       # Apply signatures to each file
       for FILE in $FILES; do
-        if ! ${TOOLING} diff-cli apply "$DIR_SIGNATURES/$FILE.signature" "$DIR_WORK/$FILE"; then
+        if ! ${TOOLING} diff-cli apply --quiet "$DIR_SIGNATURES/$FILE.signature" "$DIR_WORK/$FILE"; then
           exit 1
         fi
 
         # Fix file permissions
         chmod 700 "$DIR_WORK/$FILE"
+
+        echo "    Detached signature has been applied to $1[$ARCH] file $FILE"
       done
 
       # Clean up

--- a/library/binary-build/scripts/resources_create.sh
+++ b/library/binary-build/scripts/resources_create.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# Copyright (c) 2023 Matthew Nelson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export LC_ALL=C
+set -e
+
+# Commands
+readonly CMD_ALL="all"
+readonly CMD_LINUX="linux"
+readonly CMD_MACOS="macos"
+readonly CMD_MINGW="mingw"
+readonly CMD_GEOIPS="geoips"
+
+# Absolute path to the directory which this script resides in
+readonly DIR=$( cd "$( dirname "$0" )" >/dev/null && pwd )
+readonly DIR_BUILT="$DIR/../built"
+readonly DIR_PROJECT="$DIR/../../.."
+
+# Programs
+readonly TOOLING="$DIR_PROJECT/tooling"
+readonly OPENSSL=$(which openssl)
+
+help() {
+  echo "
+    $0
+    Copyright (C) 2023 Matthew Nelson
+    License Apache 2.0
+
+    Apply codesignatures (if applicable), gzips, and moves files to their
+    respective module resource directories.
+
+    Location: $DIR
+    Syntax: $0 [command]
+
+    Commands:
+          $CMD_ALL
+          $CMD_GEOIPS
+          $CMD_LINUX
+          $CMD_MACOS
+          $CMD_MINGW
+
+    Example: $0 $CMD_MACOS
+  "
+}
+
+initialize() {
+  if ! . "$DIR/source.sh"; then
+    echo "
+    ERROR: Failed to source source.sh
+    "
+    exit 1
+  fi
+
+  check_find
+  check_tar
+
+  if [ "$OPENSSL" = "" ]; then
+    echo "
+    ERROR: openssl is required to be installed to run this script
+    "
+    exit 1
+  fi
+}
+
+geoips() {
+  # TODO
+  echo "
+  $CMD_GEOIPS
+  "
+}
+
+binaries() {
+  # TODO
+  echo "
+  $1
+  "
+}
+
+case $1 in
+  "$CMD_ALL")
+    initialize
+
+    geoips
+    binaries "$CMD_LINUX"
+    binaries "$CMD_MACOS"
+    binaries "$CMD_MINGW"
+    ;;
+  "$CMD_GEOIPS")
+    initialize
+    geoips
+    ;;
+  "$CMD_LINUX"|"$CMD_MACOS"|"$CMD_MINGW")
+    initialize
+    binaries "$1"
+    ;;
+  *)
+    help
+    ;;
+esac
+
+exit 0

--- a/library/binary-build/scripts/source.sh
+++ b/library/binary-build/scripts/source.sh
@@ -14,32 +14,12 @@
 # limitations under the License.
 
 readonly FIND=$(which find)
-readonly GIT=$(which git)
-readonly MAKE=$(which make)
 readonly TAR=$(which tar)
 
 check_find() {
   if [ "$FIND" = "" ]; then
     echo "
     ERROR: find is required to be installed to run this script
-    "
-    exit 1
-  fi
-}
-
-check_git() {
-  if [ "$GIT" = "" ]; then
-    echo "
-    ERROR: git is required to be installed to run this script
-    "
-    exit 1
-  fi
-}
-
-check_make() {
-  if [ "$MAKE" = "" ]; then
-    echo "
-    ERROR: make is required to be installed to run this script
     "
     exit 1
   fi


### PR DESCRIPTION
Closes #70 

This PR adds a script which applies signatures (when applicable), gzips files, moves them to their appropriate module resource directory, and updates their respective `TorResource.kt` variables.