### PR TITLE
Adds dynamic modeling of resources based off of host/architecture

### DIFF
--- a/library/binary-android-unit-test/src/androidMain/kotlin/io/matthewnelson/kmp/tor/binary/android/unit/test/Loader.kt
+++ b/library/binary-android-unit-test/src/androidMain/kotlin/io/matthewnelson/kmp/tor/binary/android/unit/test/Loader.kt
@@ -15,5 +15,9 @@
  **/
 package io.matthewnelson.kmp.tor.binary.android.unit.test
 
+/**
+ * Found via reflection in order to access
+ * resources that this module provides.
+ * */
 @Suppress("unused")
 private class Loader

--- a/library/binary-util/api/binary-util.api
+++ b/library/binary-util/api/binary-util.api
@@ -4,6 +4,9 @@ public final class io/matthewnelson/kmp/tor/binary/util/AndroidSdkIntKt {
 public abstract interface annotation class io/matthewnelson/kmp/tor/binary/util/InternalKmpTorBinaryApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class io/matthewnelson/kmp/tor/binary/util/KmpTorBinaryDsl : java/lang/annotation/Annotation {
+}
+
 public final class io/matthewnelson/kmp/tor/binary/util/OSInfo$Companion {
 }
 

--- a/library/binary-util/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Annotations.kt
+++ b/library/binary-util/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Annotations.kt
@@ -38,7 +38,19 @@ package io.matthewnelson.kmp.tor.binary.util
     AnnotationTarget.FUNCTION,
     AnnotationTarget.PROPERTY_GETTER,
     AnnotationTarget.PROPERTY_SETTER,
-    AnnotationTarget.TYPEALIAS
+    AnnotationTarget.TYPEALIAS,
 )
 @Retention(AnnotationRetention.BINARY)
 public annotation class InternalKmpTorBinaryApi
+
+/**
+ * A marker annotations for DSLs.
+ */
+@DslMarker
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.TYPE,
+)
+public annotation class KmpTorBinaryDsl

--- a/library/binary-util/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Immutable.kt
+++ b/library/binary-util/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Immutable.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.binary.util
+
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
+
+@InternalKmpTorBinaryApi
+public class ImmutableSet<T> private constructor(
+    delegate: MutableSet<T>
+): Set<T> {
+    private val delegate = delegate.toSet()
+
+    override val size: Int get() = delegate.size
+    override fun isEmpty(): Boolean = delegate.isEmpty()
+    override fun iterator(): Iterator<T> = delegate.iterator()
+    override fun containsAll(elements: Collection<T>): Boolean = delegate.containsAll(elements)
+    override fun contains(element: T): Boolean = delegate.contains(element)
+
+    @InternalKmpTorBinaryApi
+    public companion object {
+
+        @JvmStatic
+        public fun <T> MutableSet<T>.toImmutableSet(): ImmutableSet<T> = ImmutableSet(this)
+    }
+}
+
+@InternalKmpTorBinaryApi
+public class ImmutableMap<K, V> private constructor(
+    delegate: MutableMap<K, V>
+): Map<K, V> {
+    private val delegate = delegate.toMap()
+
+    override val entries: Set<Map.Entry<K, V>> get() = delegate.entries
+    override val keys: Set<K> get() = delegate.keys
+    override val size: Int get() = delegate.size
+    override val values: Collection<V> get() = delegate.values
+    override fun isEmpty(): Boolean = delegate.isEmpty()
+    override operator fun get(key: K): V? = delegate[key]
+    override fun containsValue(value: V): Boolean = delegate.containsValue(value)
+    override fun containsKey(key: K): Boolean = delegate.containsKey(key)
+
+    @InternalKmpTorBinaryApi
+    public companion object {
+
+        @JvmStatic
+        public fun <K, V> MutableMap<K, V>.toImmutableMap(): ImmutableMap<K, V> = ImmutableMap(this)
+    }
+}

--- a/library/binary-util/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Resource.kt
+++ b/library/binary-util/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Resource.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.binary.util
+
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
+
+@InternalKmpTorBinaryApi
+public expect class Resource {
+
+    @JvmField
+    public val alias: String
+    @JvmField
+    public val isExecutable: Boolean
+
+    @InternalKmpTorBinaryApi
+    public class Config private constructor(
+        errors: Set<String>,
+        resources: Set<Resource>,
+    ) {
+
+        @JvmField
+        public val errors: Set<String>
+        @JvmField
+        public val resources: Set<Resource>
+
+        @Throws(Exception::class)
+        public fun extractTo(destinationDir: String): Map<String, String>
+
+        @InternalKmpTorBinaryApi
+        public companion object {
+
+            @JvmStatic
+            public fun create(block: Builder.() -> Unit): Config
+        }
+
+        @KmpTorBinaryDsl
+        @InternalKmpTorBinaryApi
+        public class Builder internal constructor() {
+
+            @KmpTorBinaryDsl
+            public fun error(message: String): Builder
+
+            @KmpTorBinaryDsl
+            public fun resource(
+                alias: String,
+                block: Resource.Builder.() -> Unit
+            ): Builder
+        }
+
+        public override fun equals(other: Any?): Boolean
+        public override fun hashCode(): Int
+        public override fun toString(): String
+    }
+
+    @KmpTorBinaryDsl
+    @InternalKmpTorBinaryApi
+    public class Builder internal constructor(alias: String) {
+
+        @JvmField
+        public val alias: String
+
+        @JvmField
+        public var isExecutable: Boolean
+    }
+
+    public override fun equals(other: Any?): Boolean
+    public override fun hashCode(): Int
+    public override fun toString(): String
+}

--- a/library/binary-util/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/util/internal/-ResourceCommon.kt
+++ b/library/binary-util/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/util/internal/-ResourceCommon.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.binary.util.internal
+
+import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
+import io.matthewnelson.kmp.tor.binary.util.Resource
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(InternalKmpTorBinaryApi::class)
+internal inline fun Resource.commonEquals(
+    other: Any?
+): Boolean = other is Resource && other.alias == alias
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(InternalKmpTorBinaryApi::class)
+internal inline fun Resource.commonHashCode(): Int = 17 * 31 + alias.hashCode()
+
+@OptIn(InternalKmpTorBinaryApi::class)
+internal fun Resource.commonToString(
+    platformFields: Map<String, Any>,
+): String = buildString {
+    appendLine("Resource: [")
+    appendIndent("alias: ")
+    append(alias)
+    appendLine()
+    appendIndent("isExecutable: ")
+    append(isExecutable)
+    appendLine()
+
+    platformFields.forEach { entry ->
+        appendIndent(entry.key)
+        append(": ")
+        append(entry.value)
+        appendLine()
+    }
+
+    append(']')
+}
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(InternalKmpTorBinaryApi::class)
+internal inline fun Resource.Config.commonEquals(
+    other: Any?
+): Boolean = other is Resource.Config && other.resources == resources
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(InternalKmpTorBinaryApi::class)
+internal inline fun Resource.Config.commonHashCode(): Int = 17 * 31 + resources.hashCode()
+
+@OptIn(InternalKmpTorBinaryApi::class)
+internal fun Resource.Config.commonToString(): String = buildString {
+    appendLine("Resource.Config: [")
+    appendIndent("errors: [")
+
+    if (errors.isEmpty()) {
+        appendLine(']')
+    } else {
+        appendLine()
+
+        errors.forEach { error ->
+            error.lines().forEach { line ->
+                appendIndent(line, "        ")
+                appendLine()
+            }
+        }
+        appendIndent(']')
+        appendLine()
+    }
+
+    appendIndent("resources: [")
+
+    if (resources.isEmpty()) {
+        appendLine(']')
+    } else {
+        appendLine()
+
+        var count = 0
+        resources.forEach { resource ->
+            resource.toString().lines().let { lines ->
+                for (i in 1..<lines.lastIndex) {
+                    appendIndent(lines[i])
+                    appendLine()
+                }
+            }
+
+            if (++count < resources.size) {
+                appendLine()
+            }
+        }
+
+        appendIndent(']')
+        appendLine()
+    }
+
+    append(']')
+}
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun StringBuilder.appendIndent(
+    value: Any,
+    indent: String = "    "
+): StringBuilder = append(indent).append(value)

--- a/library/binary-util/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Resource.kt
+++ b/library/binary-util/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Resource.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.binary.util
+
+import io.matthewnelson.kmp.tor.binary.util.ImmutableSet.Companion.toImmutableSet
+import io.matthewnelson.kmp.tor.binary.util.internal.commonEquals
+import io.matthewnelson.kmp.tor.binary.util.internal.commonHashCode
+import io.matthewnelson.kmp.tor.binary.util.internal.commonToString
+
+@InternalKmpTorBinaryApi
+public actual class Resource private constructor(
+    public actual val alias: String,
+    public actual val isExecutable: Boolean,
+    public val moduleName: String,
+    public val resourcePath: String,
+) {
+
+    @InternalKmpTorBinaryApi
+    public actual class Config private actual constructor(
+        public actual val errors: Set<String>,
+        public actual val resources: Set<Resource>,
+    ) {
+
+        @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+        public actual fun extractTo(destinationDir: String): Map<String, String> {
+            // TODO
+            return emptyMap()
+        }
+
+        @InternalKmpTorBinaryApi
+        public actual companion object {
+
+            @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+            public actual fun create(block: Builder.() -> Unit): Config = Builder().apply(block).build()
+        }
+
+        @KmpTorBinaryDsl
+        @InternalKmpTorBinaryApi
+        public actual class Builder internal actual constructor() {
+
+            private val errors = mutableSetOf<String>()
+            private val resources = mutableSetOf<Resource>()
+
+            @KmpTorBinaryDsl
+            public actual fun error(
+                message: String
+            ): Builder {
+                if (message.isNotBlank()) {
+                    errors.add(message)
+                }
+                return this
+            }
+
+            @KmpTorBinaryDsl
+            public actual fun resource(
+                alias: String,
+                block: Resource.Builder.() -> Unit
+            ): Builder {
+                if (alias.isBlank()) return this
+
+                val res = Builder(alias).apply(block).build()
+                if (res != null) {
+                    resources.add(res)
+                }
+                return this
+            }
+
+            internal fun build(): Config = Config(
+                errors.toImmutableSet(),
+                resources.toImmutableSet(),
+            )
+        }
+
+        public actual override fun equals(other: Any?): Boolean = commonEquals(other)
+        public actual override fun hashCode(): Int = commonHashCode()
+        public actual override fun toString(): String = commonToString()
+    }
+
+    @KmpTorBinaryDsl
+    @InternalKmpTorBinaryApi
+    public actual class Builder internal actual constructor(
+        public actual val alias: String
+    ) {
+
+        public actual var isExecutable: Boolean = false
+
+        public var moduleName: String = ""
+
+        public var resourcePath: String = ""
+
+        internal fun build(): Resource? {
+            val module = moduleName.ifBlank { return null }
+            val path = resourcePath.ifBlank { return null }
+
+            return Resource(
+                alias,
+                isExecutable,
+                module,
+                path,
+            )
+        }
+    }
+
+    public actual override fun equals(other: Any?): Boolean = commonEquals(other)
+    public actual override fun hashCode(): Int = commonHashCode()
+    public actual override fun toString(): String = commonToString(buildMap(2) {
+        put("moduleName", moduleName)
+        put("resourcePath", resourcePath)
+    })
+}

--- a/library/binary-util/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Resource.kt
+++ b/library/binary-util/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/util/Resource.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.binary.util
+
+import io.matthewnelson.kmp.tor.binary.util.ImmutableSet.Companion.toImmutableSet
+import io.matthewnelson.kmp.tor.binary.util.internal.commonEquals
+import io.matthewnelson.kmp.tor.binary.util.internal.commonHashCode
+import io.matthewnelson.kmp.tor.binary.util.internal.commonToString
+
+@InternalKmpTorBinaryApi
+public actual class Resource private constructor(
+    @JvmField
+    public actual val alias: String,
+    @JvmField
+    public actual val isExecutable: Boolean,
+    @JvmField
+    public val resourceClass: Class<*>,
+    @JvmField
+    public val resourcePath: String,
+) {
+
+    @InternalKmpTorBinaryApi
+    public actual class Config private actual constructor(
+        @JvmField
+        public actual val errors: Set<String>,
+        @JvmField
+        public actual val resources: Set<Resource>,
+    ) {
+
+        @Throws(Exception::class)
+        public actual fun extractTo(destinationDir: String): Map<String, String> {
+            // TODO
+            return emptyMap()
+        }
+
+        @InternalKmpTorBinaryApi
+        public actual companion object {
+
+            @JvmStatic
+            public actual fun create(block: Builder.() -> Unit): Config = Builder().apply(block).build()
+        }
+
+        @KmpTorBinaryDsl
+        @InternalKmpTorBinaryApi
+        public actual class Builder internal actual constructor() {
+
+            private val errors = mutableSetOf<String>()
+            private val resources = mutableSetOf<Resource>()
+
+            @KmpTorBinaryDsl
+            public actual fun error(
+                message: String
+            ): Builder {
+                if (message.isNotBlank()) {
+                    errors.add(message)
+                }
+                return this
+            }
+
+            @KmpTorBinaryDsl
+            public actual fun resource(
+                alias: String,
+                block: Resource.Builder.() -> Unit
+            ): Builder {
+                if (alias.isBlank()) return this
+
+                val resource = Builder(alias).apply(block).build()
+                if (resource != null) {
+                    resources.add(resource)
+                }
+                return this
+            }
+
+            internal fun build(): Config = Config(
+                errors.toImmutableSet(),
+                resources.toImmutableSet(),
+            )
+        }
+
+        public actual override fun equals(other: Any?): Boolean = commonEquals(other)
+        public actual override fun hashCode(): Int = commonHashCode()
+        public actual override fun toString(): String = commonToString()
+    }
+
+    @KmpTorBinaryDsl
+    @InternalKmpTorBinaryApi
+    public actual class Builder internal actual constructor(
+        @JvmField
+        public actual val alias: String
+    ) {
+
+        @JvmField
+        public actual var isExecutable: Boolean = false
+
+        @JvmField
+        public var resourceClass: Class<*>? = null
+
+        @JvmField
+        public var resourcePath: String = ""
+
+
+        internal fun build(): Resource? {
+            val clazz = resourceClass ?: return null
+            val path = resourcePath.ifBlank { return null }
+
+            return Resource(
+                alias,
+                isExecutable,
+                clazz,
+                path,
+            )
+        }
+    }
+
+    public actual override fun equals(other: Any?): Boolean = commonEquals(other)
+    public actual override fun hashCode(): Int = commonHashCode()
+    public actual override fun toString(): String = commonToString(buildMap(2) {
+        put("resourceClass", resourceClass)
+        put("resourcePath", resourcePath)
+    })
+}

--- a/library/binary-util/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/binary/util/OSArch.kt
+++ b/library/binary-util/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/binary/util/OSArch.kt
@@ -31,6 +31,8 @@ public sealed class OSArch private constructor(
     public val path: String
 ) {
 
+    public fun isSupportedBy(osHost: OSHost): Boolean = osHost.arches.contains(this)
+
     @InternalKmpTorBinaryApi
     public object Aarch64: OSArch("aarch64")
     @InternalKmpTorBinaryApi

--- a/library/binary/api/android/binary.api
+++ b/library/binary/api/android/binary.api
@@ -1,0 +1,14 @@
+public final class io/matthewnelson/kmp/tor/binary/KmpTorBinary {
+	public final field installationDir Ljava/lang/String;
+	public fun <init> (Ljava/io/File;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/nio/file/Path;)V
+	public final fun install ()Ljava/util/Map;
+}
+
+public final class io/matthewnelson/kmp/tor/binary/KmpTorBinaryKt {
+	public static final field ALIAS_GEOIP Ljava/lang/String;
+	public static final field ALIAS_GEOIP6 Ljava/lang/String;
+	public static final field ALIAS_TOR Ljava/lang/String;
+}
+

--- a/library/binary/api/jvm/binary.api
+++ b/library/binary/api/jvm/binary.api
@@ -1,0 +1,14 @@
+public final class io/matthewnelson/kmp/tor/binary/KmpTorBinary {
+	public final field installationDir Ljava/lang/String;
+	public fun <init> (Ljava/io/File;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/nio/file/Path;)V
+	public final fun install ()Ljava/util/Map;
+}
+
+public final class io/matthewnelson/kmp/tor/binary/KmpTorBinaryKt {
+	public static final field ALIAS_GEOIP Ljava/lang/String;
+	public static final field ALIAS_GEOIP6 Ljava/lang/String;
+	public static final field ALIAS_TOR Ljava/lang/String;
+}
+

--- a/library/binary/build.gradle.kts
+++ b/library/binary/build.gradle.kts
@@ -73,5 +73,24 @@ kmpConfiguration {
                 }
             }
         }
+
+        kotlin {
+            with(sourceSets) {
+                val jsMain = findByName("jsMain")
+                val jvmAndroidMain = findByName("jvmAndroidMain")
+
+                if (jsMain != null || jvmAndroidMain != null) {
+                    val nonNativeMain = maybeCreate("nonNativeMain")
+                    nonNativeMain.dependsOn(getByName("commonMain"))
+                    jvmAndroidMain?.apply { dependsOn(nonNativeMain) }
+                    jsMain?.apply { dependsOn(nonNativeMain) }
+
+                    val nonNativeTest = maybeCreate("nonNativeTest")
+                    nonNativeTest.dependsOn(getByName("commonTest"))
+                    findByName("jvmAndroidTest")?.apply { dependsOn(nonNativeTest) }
+                    findByName("jsTest")?.apply { dependsOn(nonNativeTest) }
+                }
+            }
+        }
     }
 }

--- a/library/binary/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinaryResourceInstrumentTest.kt
+++ b/library/binary/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinaryResourceInstrumentTest.kt
@@ -15,5 +15,16 @@
  **/
 package io.matthewnelson.kmp.tor.binary
 
-// TODO: Remove
-internal fun stub() { /* no-op */ }
+import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(InternalKmpTorBinaryApi::class)
+class KmpTorBinaryResourceInstrumentTest {
+
+    @Test
+    fun givenResourceConfig_whenAndroidEmulator_thenConfigLoadsOnlyGeoips() {
+        assertEquals(0, KmpTorBinary.Config.errors.size)
+        assertEquals(2, KmpTorBinary.Config.resources.size)
+    }
+}

--- a/library/binary/src/androidMain/kotlin/io/matthewnelson/kmp/tor/binary/internal/-AndroidPlatform.kt
+++ b/library/binary/src/androidMain/kotlin/io/matthewnelson/kmp/tor/binary/internal/-AndroidPlatform.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.binary.internal
+
+import io.matthewnelson.kmp.tor.binary.ALIAS_GEOIP
+import io.matthewnelson.kmp.tor.binary.ALIAS_GEOIP6
+import io.matthewnelson.kmp.tor.binary.ALIAS_TOR
+import io.matthewnelson.kmp.tor.binary.KmpTorBinary
+import io.matthewnelson.kmp.tor.binary.util.*
+
+@JvmSynthetic
+@OptIn(InternalKmpTorBinaryApi::class)
+internal actual fun Resource.Config.Builder.configure() {
+    val clazz = KmpTorBinary::class.java
+
+    resource(ALIAS_GEOIP) {
+        isExecutable = false
+        resourceClass = clazz
+        resourcePath = PATH_RESOURCE_GEOIP
+    }
+
+    resource(ALIAS_GEOIP6) {
+        isExecutable = false
+        resourceClass = clazz
+        resourcePath = PATH_RESOURCE_GEOIP6
+    }
+
+    // Is Android Runtime.
+    //
+    // Binaries are extracted on application install
+    // to the nativeLib directory. This is required as
+    // android does not allow execution from the app dir
+    // (cannot download executables and run them).
+    if (ANDROID_SDK_INT != null) return
+
+    // Android Unit Test. Check for support via binary-android-unit-test
+    val host = OSInfo.INSTANCE.osHost
+
+    if (host is OSHost.Unknown) {
+        error("Unknown host[$host]")
+        return
+    }
+
+    val arch = OSInfo.INSTANCE.osArch
+
+    val torResourcePath = host.toTorResourcePath(arch)
+
+    if (torResourcePath == null) {
+        error("Unsupported architecutre[$arch] for host[$host]")
+        return
+    }
+
+    val loader = "io.matthewnelson.kmp.tor.binary.android.unit.test.Loader"
+
+    val loaderClass = try {
+        Class
+            .forName(loader)
+            ?: throw ClassNotFoundException("Failed to find class $loader")
+    } catch (t: Throwable) {
+        error("""
+            Failed to find class $loader
+            Missing dependency for Android Unit Tests?
+
+            Try adding the 'binary-android-unit-test' dependency
+            via testImplementation
+        """.trimIndent())
+        return
+    }
+
+    resource(ALIAS_TOR) {
+        isExecutable = true
+        resourceClass = loaderClass
+        resourcePath = torResourcePath
+    }
+}

--- a/library/binary/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinary.kt
+++ b/library/binary/src/commonMain/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinary.kt
@@ -13,22 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package io.matthewnelson.kmp.tor.binary
 
 import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
-import io.matthewnelson.kmp.tor.binary.util.OSHost
-import io.matthewnelson.kmp.tor.binary.util.OSInfo
-import kotlin.test.Test
-import kotlin.test.assertFalse
+import io.matthewnelson.kmp.tor.binary.util.Resource
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
 
-@OptIn(InternalKmpTorBinaryApi::class)
-class OSInfoUnitTest {
+public const val ALIAS_TOR: String = "tor"
+public const val ALIAS_GEOIP: String = "geoip"
+public const val ALIAS_GEOIP6: String = "geoip6"
 
-    @Test
-    fun givenOSInfo_whenAndroidUnitTestNotEmulator_thenHostIsNotLinuxAndroid() {
-        // Should register as the host machine running unit tests, not android
-        // This will fail if test being executed via Termux, but willing to take
-        // that chance..........
-        assertFalse(OSInfo.INSTANCE.osHost is OSHost.Linux.Android)
+public expect class KmpTorBinary(installationDir: String) {
+
+    @JvmField
+    public val installationDir: String
+
+    @Throws(Exception::class)
+    public fun install(): Map<String, String>
+
+    internal companion object {
+
+        @get:JvmSynthetic
+        @OptIn(InternalKmpTorBinaryApi::class)
+        internal val Config: Resource.Config
     }
 }

--- a/library/binary/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinary.kt
+++ b/library/binary/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinary.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.binary
+
+import io.matthewnelson.kmp.tor.binary.internal.configure
+import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
+import io.matthewnelson.kmp.tor.binary.util.Resource
+
+public actual class KmpTorBinary
+public actual constructor(
+    public actual val installationDir: String
+) {
+
+    private var map: Map<String, String>? = null
+
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+    public actual fun install(): Map<String, String> {
+        // TODO: synchronized
+        @OptIn(InternalKmpTorBinaryApi::class)
+        return map ?: Config.extractTo(installationDir)
+            .also { map = it }
+    }
+
+    internal actual companion object {
+
+        @OptIn(InternalKmpTorBinaryApi::class)
+        internal actual val Config: Resource.Config by lazy {
+            // lazily load so that OSInfo doesn't
+            // hammer main thread.
+            Resource.Config.create { configure() }
+        }
+    }
+}

--- a/library/binary/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/internal/-JsPlatform.kt
+++ b/library/binary/src/jsMain/kotlin/io/matthewnelson/kmp/tor/binary/internal/-JsPlatform.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.binary.internal
+
+import io.matthewnelson.kmp.tor.binary.ALIAS_GEOIP
+import io.matthewnelson.kmp.tor.binary.ALIAS_GEOIP6
+import io.matthewnelson.kmp.tor.binary.ALIAS_TOR
+import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
+import io.matthewnelson.kmp.tor.binary.util.OSHost
+import io.matthewnelson.kmp.tor.binary.util.OSInfo
+import io.matthewnelson.kmp.tor.binary.util.Resource
+
+@OptIn(InternalKmpTorBinaryApi::class)
+@Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+internal actual fun Resource.Config.Builder.configure() {
+    val module = "kmp-tor-binary-resources"
+
+    resource(ALIAS_GEOIP) {
+        isExecutable = false
+        moduleName = module
+        resourcePath = PATH_RESOURCE_GEOIP
+    }
+
+    resource(ALIAS_GEOIP6) {
+        isExecutable = false
+        moduleName = module
+        resourcePath = PATH_RESOURCE_GEOIP6
+    }
+
+    val host = OSInfo.INSTANCE.osHost
+
+    if (host is OSHost.Unknown) {
+        error("Unknown host[$host]")
+        return
+    }
+
+    val arch = OSInfo.INSTANCE.osArch
+
+    val torResourcePath = host.toTorResourcePath(arch)
+
+    if (torResourcePath == null) {
+        error("Unsupported architecutre[$arch] for host[$host]")
+        return
+    }
+
+    resource(ALIAS_TOR) {
+        isExecutable = true
+        moduleName = module
+        resourcePath = torResourcePath
+    }
+}

--- a/library/binary/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinary.kt
+++ b/library/binary/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinary.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.binary
+
+import io.matthewnelson.kmp.tor.binary.internal.configure
+import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
+import io.matthewnelson.kmp.tor.binary.util.Resource
+import java.io.File
+import java.nio.file.Path
+import kotlin.concurrent.Volatile
+import kotlin.io.path.absolutePathString
+
+public actual class KmpTorBinary
+public actual constructor(
+    @JvmField
+    public actual val installationDir: String
+) {
+
+    public constructor(installationDir: File): this(installationDir.absolutePath)
+    public constructor(installationDir: Path): this(installationDir.absolutePathString())
+
+    @Volatile
+    private var map: Map<String, String>? = null
+
+    @Throws(Exception::class)
+    public actual fun install(): Map<String, String> {
+        return map ?: synchronized(this) {
+            @OptIn(InternalKmpTorBinaryApi::class)
+            map ?: run {
+                // TODO: Maybe for android could have a separate
+                //  module that uses androidx-setup to find the
+                //  native library to return the ALIAS_TOR path
+                //  here? That module could also be used for
+                //  pluggable transports, too.
+
+                Config.extractTo(installationDir)
+                    .also { map = it }
+            }
+        }
+    }
+
+    internal actual companion object {
+
+        @get:JvmSynthetic
+        @OptIn(InternalKmpTorBinaryApi::class)
+        internal actual val Config: Resource.Config by lazy {
+            // lazily load so that OSInfo doesn't
+            // hammer main thread.
+            Resource.Config.create { configure() }
+        }
+    }
+}

--- a/library/binary/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/internal/-JvmPlatform.kt
+++ b/library/binary/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/binary/internal/-JvmPlatform.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.binary.internal
+
+import io.matthewnelson.kmp.tor.binary.ALIAS_GEOIP
+import io.matthewnelson.kmp.tor.binary.ALIAS_GEOIP6
+import io.matthewnelson.kmp.tor.binary.ALIAS_TOR
+import io.matthewnelson.kmp.tor.binary.KmpTorBinary
+import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
+import io.matthewnelson.kmp.tor.binary.util.OSHost
+import io.matthewnelson.kmp.tor.binary.util.OSInfo
+import io.matthewnelson.kmp.tor.binary.util.Resource
+
+@JvmSynthetic
+@OptIn(InternalKmpTorBinaryApi::class)
+internal actual fun Resource.Config.Builder.configure() {
+    val clazz = KmpTorBinary::class.java
+
+    resource(ALIAS_GEOIP) {
+        isExecutable = false
+        resourceClass = clazz
+        resourcePath = PATH_RESOURCE_GEOIP
+    }
+
+    resource(ALIAS_GEOIP6) {
+        isExecutable = false
+        resourceClass = clazz
+        resourcePath = PATH_RESOURCE_GEOIP6
+    }
+
+    val host = OSInfo.INSTANCE.osHost
+
+    if (host is OSHost.Unknown) {
+        error("Unknown host[$host]")
+        return
+    }
+
+    val arch = OSInfo.INSTANCE.osArch
+
+    val torResourcePath = host.toTorResourcePath(arch)
+
+    if (torResourcePath == null) {
+        error("Unsupported architecutre[$arch] for host[$host]")
+        return
+    }
+
+    resource(ALIAS_TOR) {
+        isExecutable = true
+        resourceClass = clazz
+        resourcePath = torResourcePath
+    }
+}

--- a/library/binary/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/binary/internal/-NonNativePlatform.kt
+++ b/library/binary/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/binary/internal/-NonNativePlatform.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
+package io.matthewnelson.kmp.tor.binary.internal
+
+import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
+import io.matthewnelson.kmp.tor.binary.util.OSArch
+import io.matthewnelson.kmp.tor.binary.util.OSHost
+import io.matthewnelson.kmp.tor.binary.util.Resource
+import kotlin.jvm.JvmSynthetic
+
+@JvmSynthetic
+internal const val PATH_RESOURCE_GEOIP = "/io/matthewnelson/kmp/tor/binary/geoip.gz"
+@JvmSynthetic
+internal const val PATH_RESOURCE_GEOIP6 = "/io/matthewnelson/kmp/tor/binary/geoip6.gz"
+
+@JvmSynthetic
+@OptIn(InternalKmpTorBinaryApi::class)
+internal expect fun Resource.Config.Builder.configure()
+
+@JvmSynthetic
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(InternalKmpTorBinaryApi::class)
+internal inline fun OSHost.toTorResourcePath(osArch: OSArch): String? {
+    if (!osArch.isSupportedBy(this)) return null
+
+    val name = when (this) {
+        is OSHost.FreeBSD,
+        is OSHost.Linux,
+        is OSHost.MacOS -> "tor.gz"
+        is OSHost.Windows -> "tor.exe.gz"
+        is OSHost.Unknown -> return null
+    }
+
+    return "/io/matthewnelson/kmp/tor/binary/native/$this/$osArch/$name"
+}

--- a/library/binary/src/nonNativeTest/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinaryResourceUnitTest.kt
+++ b/library/binary/src/nonNativeTest/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinaryResourceUnitTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.binary
+
+import io.matthewnelson.kmp.tor.binary.util.InternalKmpTorBinaryApi
+import io.matthewnelson.kmp.tor.binary.util.OSInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(InternalKmpTorBinaryApi::class)
+class KmpTorBinaryResourceUnitTest {
+
+    @Test
+    fun givenTorBinaryResources_whenConfigured_thenIsExpectedForHostMachine() {
+        if (!OSInfo.INSTANCE.osArch.isSupportedBy(OSInfo.INSTANCE.osHost)) {
+            // If host machine running this test is not supported, the
+            // tor binaries will not be configured and an error will
+            // be added instead.
+            assertEquals(1, KmpTorBinary.Config.errors.size)
+            assertEquals(2, KmpTorBinary.Config.resources.size)
+        } else {
+            // Specifically for Android, this should obtain the Loader
+            // class from module :binary-android-unit-test and have
+            // the appropriate resources to load for the host machine.
+            assertEquals(0, KmpTorBinary.Config.errors.size)
+            assertEquals(3, KmpTorBinary.Config.resources.size)
+        }
+
+        println(KmpTorBinary.Config)
+    }
+}


### PR DESCRIPTION
Part of #96 

Adds via module `:binary-util` the ability to model resources in a dynamic, and platform specific manner based off of `OSInfo` for the given host machine, and lazily install to specified directory.

Example output:

Node.js
```
    Resource.Config: [
        errors: []
        resources: [
            alias: geoip
            isExecutable: false
            moduleName: kmp-tor-binary-resources
            resourcePath: /io/matthewnelson/kmp/tor/binary/geoip.gz

            alias: geoip6
            isExecutable: false
            moduleName: kmp-tor-binary-resources
            resourcePath: /io/matthewnelson/kmp/tor/binary/geoip6.gz

            alias: tor
            isExecutable: true
            moduleName: kmp-tor-binary-resources
            resourcePath: /io/matthewnelson/kmp/tor/binary/native/linux-libc/x86_64/tor.gz
        ]
    ]
```

Android (Unit Test, not Emulator)
```
    Resource.Config: [
        errors: []
        resources: [
            alias: geoip
            isExecutable: false
            resourceClass: class io.matthewnelson.kmp.tor.binary.KmpTorBinary
            resourcePath: /io/matthewnelson/kmp/tor/binary/geoip.gz

            alias: geoip6
            isExecutable: false
            resourceClass: class io.matthewnelson.kmp.tor.binary.KmpTorBinary
            resourcePath: /io/matthewnelson/kmp/tor/binary/geoip6.gz

            alias: tor
            isExecutable: true
            resourceClass: class io.matthewnelson.kmp.tor.binary.android.unit.test.Loader
            resourcePath: /io/matthewnelson/kmp/tor/binary/native/linux-libc/x86_64/tor.gz
        ]
    ]
```

Jvm
```
    Resource.Config: [
        errors: []
        resources: [
            alias: geoip
            isExecutable: false
            resourceClass: class io.matthewnelson.kmp.tor.binary.KmpTorBinary
            resourcePath: /io/matthewnelson/kmp/tor/binary/geoip.gz

            alias: geoip6
            isExecutable: false
            resourceClass: class io.matthewnelson.kmp.tor.binary.KmpTorBinary
            resourcePath: /io/matthewnelson/kmp/tor/binary/geoip6.gz

            alias: tor
            isExecutable: true
            resourceClass: class io.matthewnelson.kmp.tor.binary.KmpTorBinary
            resourcePath: /io/matthewnelson/kmp/tor/binary/native/linux-libc/x86_64/tor.gz
        ]
    ]
```