### PR TITLE
Update `kmp-file` (fixes `chmod`)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,12 +7,12 @@ encoding = "2.1.0"
 
 gradle-android = "8.1.4"
 gradle-binary-compat = "0.13.2"
-gradle-kmp-configuration = "0.1.5"
+gradle-kmp-configuration = "0.1.6"
 gradle-kotlin = "1.9.21"
 gradle-publish-maven = "0.25.3"
 gradle-publish-npm = "3.4.1"
 
-kmp-file = "0.1.0-alpha01"
+kmp-file = "0.1.0-alpha02"
 
 kotlincrypto-hash = "0.4.0"
 kotlinx-atomicfu = "0.23.1"

--- a/library/binary/src/nativeTest/kotlin/io/matthewnelson/kmp/tor/binary/-NativeTestPlatform.kt
+++ b/library/binary/src/nativeTest/kotlin/io/matthewnelson/kmp/tor/binary/-NativeTestPlatform.kt
@@ -16,5 +16,8 @@
 package io.matthewnelson.kmp.tor.binary
 
 import io.matthewnelson.kmp.file.File
+import io.matthewnelson.kmp.file.path
+import platform.posix.X_OK
+import platform.posix.access
 
-actual fun File.isExecutable(): Boolean = TODO()
+actual fun File.isExecutable(): Boolean = access(path, X_OK) == 0

--- a/library/binary/src/nativeTest/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinaryNativeUnitTest.kt
+++ b/library/binary/src/nativeTest/kotlin/io/matthewnelson/kmp/tor/binary/KmpTorBinaryNativeUnitTest.kt
@@ -15,12 +15,13 @@
  **/
 package io.matthewnelson.kmp.tor.binary
 
+import kotlin.experimental.ExperimentalNativeApi
 import kotlin.test.Test
 
 class KmpTorBinaryNativeUnitTest: KmpTorBinaryBaseTest() {
 
-    // TODO: Implement File.isExecutable() test function
-    override val isWindows: Boolean = true
+    @OptIn(ExperimentalNativeApi::class)
+    override val isWindows: Boolean = Platform.osFamily == OsFamily.WINDOWS
 
     @Test
     fun stub() {}


### PR DESCRIPTION
Closes #169 

Linux permissions for `tor`, `geoip`, `geoip6`:

![image](https://github.com/05nelsonm/kmp-tor-binary/assets/44778092/5b66f455-bf36-4160-8039-9756ae77c2d7)
